### PR TITLE
Add dump bitbucket repos in naive way

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -15,15 +15,7 @@ func Clone(url, directory string, creds struct {
 	Password string
 } /* branches []string */) {
 	fmt.Printf("Cloning repo: %s to folder: %s\n", url, directory)
-	// systemUser, err := user.Current()
-	// if err != nil {
-	// 	log.Fatalf("Failed getting current system user: %s", err)
-	// 	return
-	// }
-
 	fullDirectoryPath := directory
-
-	fmt.Printf("Repo will be cloned here: %s\n", fullDirectoryPath)
 
 	// TODO: implement fetching branches
 	// TODO: implement letting user know which repos are > 1Gb


### PR DESCRIPTION
Just wrote a simple dumping process as I had years back. I dumps pretty well but still takes time. There is room for improvement like adding concurrency to launch 5 go routines to clone 5 repos at the same time (not sure if that won't run into rate limiting issue). 