### PR TITLE
Convert bare into regular

### DIFF
--- a/convert_repository.go
+++ b/convert_repository.go
@@ -1,0 +1,153 @@
+package dumper
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+var (
+	ErrRepositoryIsNonBare = errors.New("repository is already non-bare")
+	ErrRepositoryIsBare    = errors.New("repository is already bare")
+)
+
+type RepositoryType int
+
+const (
+	RepositoryTypeBare RepositoryType = iota
+	RepositoryTypeNonBare
+)
+
+type Converter interface {
+	Convert(destination string, repoType RepositoryType) error
+}
+
+// Convert converts git repository from bare to non-bare and vice versa
+func Convert(destination string, convertToRepoType RepositoryType) error {
+	repository, err := Repository(destination)
+	if err != nil {
+		return fmt.Errorf("convert repository: %w", err)
+	}
+	config, err := repository.Config()
+	if err != nil {
+		return fmt.Errorf("convert repository: %w", err)
+	}
+
+	switch convertToRepoType {
+	case RepositoryTypeBare:
+		if ok := config.Core.IsBare; ok {
+			return ErrRepositoryIsBare
+		}
+
+		err = convertToBare(destination)
+		if err != nil {
+			return fmt.Errorf("convert repository: %w", err)
+		}
+
+		return nil
+	case RepositoryTypeNonBare:
+		if ok := config.Core.IsBare; !ok {
+			return ErrRepositoryIsNonBare
+		}
+		return convertToNonBare(repository, destination)
+	default:
+		return errors.New("unknown repository type")
+	}
+}
+
+func convertToNonBare(repository *git.Repository, destination string) error {
+	rConfig, err := repository.Config()
+	if err != nil {
+		return err
+	}
+
+	rConfig.Core.IsBare = false
+	repository.SetConfig(rConfig)
+
+	err = os.Mkdir(filepath.Join(destination, ".git"), 0755)
+	if err != nil {
+		return fmt.Errorf("init repo: %w", err)
+	}
+
+	// move all content of repository into .git
+	// we need this because after checkout files from
+	// branch will be placed into root directory
+	err = moveFolderContent(destination, filepath.Join(destination, ".git"))
+	if err != nil {
+		return fmt.Errorf("move bare repo content into .git: %w", err)
+	}
+
+	// once git-related files are moved into .git
+	// it won't have any knowledge about branches
+	// so we need to read .git folder again as current
+	// repository instance does nothing about new fs structure
+	repository, err = git.PlainOpen(destination)
+	if err != nil {
+		return fmt.Errorf("open repository: %w", err)
+	}
+
+	refs, err := repository.References()
+	if err != nil {
+		return err
+	}
+	err = refs.ForEach(func(ref *plumbing.Reference) error {
+		if ref.Type() == plumbing.HashReference {
+			branchName := ref.Name().Short()
+			branchRef := plumbing.NewBranchReferenceName(branchName)
+			worktree, err := repository.Worktree()
+			if err != nil {
+				return fmt.Errorf("create worktree %s: %s", branchName, err)
+			}
+
+			err = worktree.Checkout(&git.CheckoutOptions{
+				Branch: branchRef,
+				Create: false,
+				Force:  true,
+			})
+			if err != nil {
+				return fmt.Errorf("checkout branch %s: %s", branchName, err)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("convert repository to non bare: %w", err)
+	}
+
+	return nil
+}
+
+// INFO: TO BE DONE
+func convertToBare(destination string) error {
+	return nil
+}
+
+func moveFolderContent(source, destination string) error {
+	files, err := os.ReadDir(source)
+	if err != nil {
+		return fmt.Errorf("read dir: %w", err)
+	}
+
+	for _, file := range files {
+		if file.Name() == ".git" {
+			continue
+		}
+
+		err := os.Rename(filepath.Join(source, file.Name()), filepath.Join(destination, file.Name()))
+		if err != nil {
+			return fmt.Errorf(
+				"move file/dir[%s] -> to [%s]: %w",
+				file.Name(),
+				filepath.Join(destination, file.Name()),
+				err,
+			)
+		}
+	}
+
+	return nil
+}

--- a/convert_repository.go
+++ b/convert_repository.go
@@ -11,6 +11,8 @@ import (
 )
 
 var (
+	ErrNotImplemented = errors.New("not implemented yet")
+
 	ErrRepositoryIsNonBare = errors.New("repository is already non-bare")
 	ErrRepositoryIsBare    = errors.New("repository is already bare")
 )
@@ -42,13 +44,7 @@ func Convert(destination string, convertToRepoType RepositoryType) error {
 		if ok := config.Core.IsBare; ok {
 			return ErrRepositoryIsBare
 		}
-
-		err = convertToBare(destination)
-		if err != nil {
-			return fmt.Errorf("convert repository: %w", err)
-		}
-
-		return nil
+		return ErrNotImplemented
 	case RepositoryTypeNonBare:
 		if ok := config.Core.IsBare; !ok {
 			return ErrRepositoryIsNonBare
@@ -119,11 +115,6 @@ func convertToNonBare(repository *git.Repository, destination string) error {
 		return fmt.Errorf("convert repository to non bare: %w", err)
 	}
 
-	return nil
-}
-
-// INFO: TO BE DONE
-func convertToBare(destination string) error {
 	return nil
 }
 

--- a/convert_repository_test.go
+++ b/convert_repository_test.go
@@ -78,3 +78,34 @@ func TestConver_FromBareToNonBare(t *testing.T) {
 	})
 	require.ElementsMatch(t, expectedBranches, actualBranches, "expect to have proper branches")
 }
+
+// TestConver_FromNonBareToBare supposed to test converting
+// from non-bare to bare repository but I see no need to have
+// this implementation yet
+func TestConver_FromNonBareToBare(t *testing.T) {
+	tempDir := os.TempDir()
+	fullDestinationPath := path.Join(filepath.Clean(tempDir), destinationRepositoryDir)
+	fmt.Println("fullDestinationPath: ", fullDestinationPath)
+
+	dumper := New()
+	opts := &DumpRepositoryOptions{
+		RepositoryURL:     testRepositoryURL,
+		Destination:       fullDestinationPath,
+		OnlyDefaultBranch: negativeBool(),
+		Creds: Creds{
+			Password: "blahblah",
+		},
+		BranchRestrictions: &BranchRestrictions{
+			SingleBranch: true,
+			BranchName:   "main",
+		},
+	}
+	repository, err := dumper.DumpRepository(opts)
+	defer os.RemoveAll(fullDestinationPath)
+	require.NoError(t, err, "expect to properly dump repository")
+	require.IsType(t, &git.Repository{}, repository, "expect to have proper repository instance")
+
+	// convert repository from non-bare to bare
+	err = Convert(fullDestinationPath, RepositoryTypeBare)
+	require.ErrorAs(t, err, &ErrNotImplemented, "expect to get not implemented error")
+}

--- a/convert_repository_test.go
+++ b/convert_repository_test.go
@@ -1,0 +1,80 @@
+package dumper
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConver_FromBareToNonBare(t *testing.T) {
+	tempDir := os.TempDir()
+	fullDestinationPath := path.Join(filepath.Clean(tempDir), destinationRepositoryDir)
+	fmt.Println("fullDestinationPath: ", fullDestinationPath)
+
+	dumper := New()
+	opts := &DumpRepositoryOptions{
+		RepositoryURL:     testRepositoryURL,
+		Destination:       fullDestinationPath,
+		OnlyDefaultBranch: negativeBool(),
+		Creds: Creds{
+			Password: "blahblah",
+		},
+		BranchRestrictions: &BranchRestrictions{
+			SingleBranch: false, // mirror branch and have it as bare on local fs
+		},
+	}
+	repository, err := dumper.DumpRepository(opts)
+	defer os.RemoveAll(fullDestinationPath)
+	require.NoError(t, err, "expect to properly dump repository")
+	require.IsType(t, &git.Repository{}, repository, "expect to have proper repository instance")
+
+	// convert repository from bare to non-bare
+	err = Convert(fullDestinationPath, RepositoryTypeNonBare)
+	require.NoError(t, err, "expect to properly convert repository from bare to non-bare")
+
+	// take new repository instance and verify if it is non-bare
+	repository, err = git.PlainOpen(fullDestinationPath)
+	require.NoError(t, err, "expect to properly open repository")
+
+	worktree, err := repository.Worktree()
+	require.NoError(t, err, "expect to properly get worktree")
+
+	files, err := worktree.Filesystem.ReadDir(".")
+	require.NoError(t, err, "expect to properly read files from worktree")
+	expectedFolderContent := []string{
+		".git",
+		"LICENSE",
+		"test-regular-file.txt",
+	}
+	actualFolderContent := []string{}
+	for _, file := range files {
+		actualFolderContent = append(actualFolderContent, file.Name())
+	}
+	require.ElementsMatch(
+		t,
+		expectedFolderContent,
+		actualFolderContent,
+		"expect to have proper folder content",
+	)
+
+	// check for branches
+	expectedBranches := []string{
+		"main",
+		"feat/test-regular-file-second-change",
+		"feat/test-regular-file-first-change",
+	}
+	actualBranches := []string{}
+	brIter, err := repository.Branches()
+	require.NoError(t, err, "expect to properly get branches iterator")
+	brIter.ForEach(func(br *plumbing.Reference) error {
+		actualBranches = append(actualBranches, br.Name().Short())
+		return nil
+	})
+	require.ElementsMatch(t, expectedBranches, actualBranches, "expect to have proper branches")
+}

--- a/convert_repository_test.go
+++ b/convert_repository_test.go
@@ -109,3 +109,41 @@ func TestConver_FromNonBareToBare(t *testing.T) {
 	err = Convert(fullDestinationPath, RepositoryTypeBare)
 	require.ErrorAs(t, err, &ErrNotImplemented, "expect to get not implemented error")
 }
+
+func TestMoveFolderContent(t *testing.T) {
+	// create a temporary source directory
+	sourceDir := filepath.Join(os.TempDir(), "sourceDir")
+	err := os.Mkdir(sourceDir, 0755)
+	require.NoError(t, err, "expect to properly create temporary source directory")
+	defer os.RemoveAll(sourceDir)
+
+	// create some files in the source directory
+	_, err = os.Create(filepath.Join(sourceDir, "file1.txt"))
+	require.NoError(t, err)
+	_, err = os.Create(filepath.Join(sourceDir, "file2.txt"))
+	require.NoError(t, err)
+
+	// create a temporary destination directory
+	destDir := filepath.Join(os.TempDir(), "destinationDir")
+	err = os.Mkdir(destDir, 0755)
+	require.NoError(t, err)
+	defer os.RemoveAll(destDir)
+
+	// move the files from the source directory to the destination directory
+	err = moveFolderContent(sourceDir, destDir)
+	require.NoError(t, err)
+
+	// check that the files were moved
+	_, err = os.Stat(filepath.Join(destDir, "file1.txt"))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(destDir, "file2.txt"))
+	require.NoError(t, err)
+
+	// try to move the files again, which should fail
+	unknownDir := filepath.Join(os.TempDir(), "unknownDir")
+	err = moveFolderContent(unknownDir, sourceDir)
+	require.Error(t, err)
+
+	// check that the error message includes the expected text
+	require.Contains(t, err.Error(), "read dir:")
+}

--- a/dumper.go
+++ b/dumper.go
@@ -1,5 +1,12 @@
 package dumper
 
+import (
+	"fmt"
+	"path"
+
+	"github.com/go-git/go-git/v5"
+)
+
 type Dumper struct {
 	skipLargeRepos     bool
 	largeRepoLimitSize uint64 // bytes
@@ -16,4 +23,15 @@ func New(options ...Option) *Dumper {
 	}
 
 	return d
+}
+
+// Repository returns git repository
+func Repository(destination string) (*git.Repository, error) {
+	destination = path.Clean(destination)
+	repository, err := git.PlainOpen(destination)
+	if err != nil {
+		return nil, fmt.Errorf("open repository: %w", err)
+	}
+
+	return repository, nil
 }

--- a/dumper_test.go
+++ b/dumper_test.go
@@ -1,14 +1,41 @@
 package dumper
 
 import (
+	"os"
+	"path"
+	"path/filepath"
 	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/stretchr/testify/require"
 )
 
 // dummy test
 func TestNew(t *testing.T) {
 	dumper := New()
+	require.NotNil(t, dumper, "expect to have proper dumper instance")
+}
 
-	if dumper == nil {
-		t.Errorf("expect to have proper dump instance")
+func TestRepository(t *testing.T) {
+	tempDir := os.TempDir()
+	fullDestinationPath := path.Join(filepath.Clean(tempDir), destinationRepositoryDir)
+
+	dumper := New()
+	opts := &DumpRepositoryOptions{
+		RepositoryURL:     testRepositoryURL,
+		Destination:       fullDestinationPath,
+		OnlyDefaultBranch: positiveBool(),
+		Creds: Creds{
+			Password: "blahblah",
+		},
 	}
+	_, err := dumper.DumpRepository(opts)
+	defer os.RemoveAll(fullDestinationPath)
+	require.NoError(t, err, "expect to properly dump repository")
+
+	// get repository by it's path
+	// and verify if it is returned as Repository instance
+	repository, err := Repository(fullDestinationPath)
+	require.NoError(t, err, "expect to properly get repository with no errors")
+	require.IsType(t, &git.Repository{}, repository, "expect to have proper repository instance")
 }


### PR DESCRIPTION
Added Convert feature to convert repository from bare into non-bare. When we clone repository using `--mirror` flag, it clones repository as bare repository. It means that repository can be used to clone from it (behaving like a remote). What Convert does is makes repository as users used to see it (with branches, proper worktree etc). I didn't add converting from regular non-bare into bare as mostly I guess there is no sense to do that, and if you want you can just pull that repository with proper options to clone it again as bare repo into proper path.