### PR TITLE
Add output configuration

### DIFF
--- a/convert_repository_test.go
+++ b/convert_repository_test.go
@@ -1,7 +1,7 @@
 package dumper
 
 import (
-	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -15,7 +15,6 @@ import (
 func TestConver_FromBareToNonBare(t *testing.T) {
 	tempDir := os.TempDir()
 	fullDestinationPath := path.Join(filepath.Clean(tempDir), destinationRepositoryDir)
-	fmt.Println("fullDestinationPath: ", fullDestinationPath)
 
 	dumper := New()
 	opts := &DumpRepositoryOptions{
@@ -27,6 +26,9 @@ func TestConver_FromBareToNonBare(t *testing.T) {
 		},
 		BranchRestrictions: &BranchRestrictions{
 			SingleBranch: false, // mirror branch and have it as bare on local fs
+		},
+		Output: &Output{
+			GitOutput: io.Discard,
 		},
 	}
 	repository, err := dumper.DumpRepository(opts)
@@ -85,7 +87,6 @@ func TestConver_FromBareToNonBare(t *testing.T) {
 func TestConver_FromNonBareToBare(t *testing.T) {
 	tempDir := os.TempDir()
 	fullDestinationPath := path.Join(filepath.Clean(tempDir), destinationRepositoryDir)
-	fmt.Println("fullDestinationPath: ", fullDestinationPath)
 
 	dumper := New()
 	opts := &DumpRepositoryOptions{
@@ -98,6 +99,9 @@ func TestConver_FromNonBareToBare(t *testing.T) {
 		BranchRestrictions: &BranchRestrictions{
 			SingleBranch: true,
 			BranchName:   "main",
+		},
+		Output: &Output{
+			GitOutput: io.Discard,
 		},
 	}
 	repository, err := dumper.DumpRepository(opts)

--- a/dump_repository_test.go
+++ b/dump_repository_test.go
@@ -46,6 +46,9 @@ func TestDumpRepository_PositiveNegativeCases(t *testing.T) {
 					Username: "",
 					Password: "blahblah",
 				},
+				Output: &Output{
+					GitOutput: io.Discard,
+				},
 			},
 			shouldFail:    true,
 			expectedError: "dump repository validate options: repository url required",
@@ -60,6 +63,9 @@ func TestDumpRepository_PositiveNegativeCases(t *testing.T) {
 					Username: "",
 					Password: "blahblah",
 				},
+				Output: &Output{
+					GitOutput: io.Discard,
+				},
 			},
 			shouldFail:    true,
 			expectedError: "dump repository validate options: destination required",
@@ -70,6 +76,9 @@ func TestDumpRepository_PositiveNegativeCases(t *testing.T) {
 				RepositoryURL:     testRepositoryURL,
 				Destination:       fullDestinationPath,
 				OnlyDefaultBranch: positiveBool(),
+				Output: &Output{
+					GitOutput: io.Discard,
+				},
 			},
 			shouldFail:    true,
 			expectedError: "dump repository validate options: username or password required",
@@ -83,6 +92,9 @@ func TestDumpRepository_PositiveNegativeCases(t *testing.T) {
 				Creds: Creds{
 					Username: "",
 				},
+				Output: &Output{
+					GitOutput: io.Discard,
+				},
 			},
 			shouldFail:    true,
 			expectedError: "dump repository validate options: username or password required",
@@ -95,6 +107,9 @@ func TestDumpRepository_PositiveNegativeCases(t *testing.T) {
 				OnlyDefaultBranch: positiveBool(),
 				Creds: Creds{
 					Password: "blahblah",
+				},
+				Output: &Output{
+					GitOutput: io.Discard,
 				},
 			},
 			shouldFail:    false,
@@ -113,6 +128,9 @@ func TestDumpRepository_PositiveNegativeCases(t *testing.T) {
 					SingleBranch: false,
 					BranchName:   "feat/test-regular-file-second-change",
 				},
+				Output: &Output{
+					GitOutput: io.Discard,
+				},
 			},
 			shouldFail:    true,
 			expectedError: "dump repository validate options: branch restrictions validate: branch name is not required when single branch is not set",
@@ -129,6 +147,9 @@ func TestDumpRepository_PositiveNegativeCases(t *testing.T) {
 				BranchRestrictions: &BranchRestrictions{
 					SingleBranch: true,
 				},
+				Output: &Output{
+					GitOutput: io.Discard,
+				},
 			},
 			shouldFail:    true,
 			expectedError: "dump repository validate options: branch restrictions validate: branch name required",
@@ -140,6 +161,9 @@ func TestDumpRepository_PositiveNegativeCases(t *testing.T) {
 				Destination:   fullDestinationPath,
 				Creds: Creds{
 					Password: "blahblah",
+				},
+				Output: &Output{
+					GitOutput: io.Discard,
 				},
 			},
 			shouldFail:    true,
@@ -156,6 +180,9 @@ func TestDumpRepository_PositiveNegativeCases(t *testing.T) {
 				},
 				BranchRestrictions: &BranchRestrictions{
 					SingleBranch: false,
+				},
+				Output: &Output{
+					GitOutput: io.Discard,
 				},
 			},
 			shouldFail: false,
@@ -191,6 +218,9 @@ func TestDumpRepository_DefaultBranch(t *testing.T) {
 		OnlyDefaultBranch: positiveBool(),
 		Creds: Creds{
 			Password: "blahblah",
+		},
+		Output: &Output{
+			GitOutput: io.Discard,
 		},
 	}
 	repository, err := dumper.DumpRepository(opts)
@@ -233,6 +263,9 @@ func TestDumpRepository_NonDefaultBranch(t *testing.T) {
 			SingleBranch: true,
 			BranchName:   "feat/test-regular-file-first-change",
 		},
+		Output: &Output{
+			GitOutput: io.Discard,
+		},
 	}
 	repository, err := dumper.DumpRepository(opts)
 	defer os.RemoveAll(fullDestinationPath)
@@ -273,6 +306,9 @@ func TestDumpRepository_DumpAllBranches(t *testing.T) {
 		},
 		BranchRestrictions: &BranchRestrictions{
 			SingleBranch: false,
+		},
+		Output: &Output{
+			GitOutput: io.Discard,
 		},
 	}
 	repository, err := dumper.DumpRepository(opts)

--- a/dumper_test.go
+++ b/dumper_test.go
@@ -1,6 +1,7 @@
 package dumper
 
 import (
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -27,6 +28,9 @@ func TestRepository(t *testing.T) {
 		OnlyDefaultBranch: positiveBool(),
 		Creds: Creds{
 			Password: "blahblah",
+		},
+		Output: &Output{
+			GitOutput: io.Discard,
 		},
 	}
 	_, err := dumper.DumpRepository(opts)

--- a/examples/dumper/cmd/provider/bitbucket/bitbucket.go
+++ b/examples/dumper/cmd/provider/bitbucket/bitbucket.go
@@ -1,6 +1,7 @@
 package bitbucket
 
 import (
+	"io"
 	"log"
 	"os"
 	"path"
@@ -56,6 +57,7 @@ var (
 								logger.Printf("=== clone repository to: %s\n", fullDestFolder)
 
 								dpr := dumper.New()
+								onlyDefaultBranch := true
 								dumpOptions := &dumper.DumpRepositoryOptions{
 									RepositoryURL: httpsCloneLink,
 									Destination:   fullDestFolder,
@@ -65,6 +67,10 @@ var (
 									}{
 										Username: Username,
 										Password: Token,
+									},
+									OnlyDefaultBranch: &onlyDefaultBranch,
+									Output: &dumper.Output{
+										GitOutput: io.Discard,
 									},
 								}
 								_, err = dpr.DumpRepository(dumpOptions)

--- a/examples/dumper/cmd/provider/github/github.go
+++ b/examples/dumper/cmd/provider/github/github.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"io"
 	"log"
 	"os"
 	"path"
@@ -41,6 +42,7 @@ var (
 				fullDestFolder := path.Join(DestinationFolder, *repo.Owner.Login, *repo.Name)
 				logger.Printf("=== clone repository to: %s\n", fullDestFolder)
 				dpr := dumper.New()
+				onlyDefaultBranch := true
 				dumpOptions := &dumper.DumpRepositoryOptions{
 					RepositoryURL: *repo.CloneURL,
 					Destination:   fullDestFolder,
@@ -50,6 +52,10 @@ var (
 					}{
 						Username: Username,
 						Password: Token,
+					},
+					OnlyDefaultBranch: &onlyDefaultBranch,
+					Output: &dumper.Output{
+						GitOutput: io.Discard,
 					},
 				}
 				_, err = dpr.DumpRepository(dumpOptions)


### PR DESCRIPTION
Output configuration helps forward Git progress into specified destination be it os.Stdout or file / io.Reader / etc.